### PR TITLE
Markdown support for jekyll-reveal

### DIFF
--- a/_layouts/slide.html
+++ b/_layouts/slide.html
@@ -56,6 +56,8 @@
 
       // Optional libraries used to extend on reveal.js
       dependencies: [
+        { src: '/reveal.js/plugin/markdown/marked.js', condition: function() { return !!document.querySelector( '[data-markdown]' ); } },
+          { src: '/reveal.js/plugin/markdown/markdown.js', condition: function() { return !!document.querySelector( '[data-markdown]' ); } },
         { src: '/reveal.js/plugin/highlight/highlight.js', async: true, callback: function() { window.hljs.initHighlightingOnLoad(); } },
         { src: '/reveal.js/lib/js/classList.js', condition: function() { return !document.body.classList; } }
       ]

--- a/_slides/test-reveal-slides-4.html
+++ b/_slides/test-reveal-slides-4.html
@@ -1,0 +1,16 @@
+---
+title: Test slide 4
+description: Write slides in markdown
+---
+
+<section data-markdown data-separator="^\n---\n$" data-vertical="^\n--\n$">
+<script type="text/template">
+
+## Demo 2
+
+---
+
+Test
+
+</script>
+</section>


### PR DESCRIPTION
Adds Markdown support for jekyll-reveal with an example slide.
- [x] Implement
- [x] Test slide
- [x] Merge
